### PR TITLE
hot-fix: Add missing exports for dashboard & process-manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 	"exports": {
 		".": "./src/api.ts",
 		"./cli": "./src/index.ts",
-		"./types": "./src/types.ts"
+		"./types": "./src/types.ts",
+		"./dashboard": "./src/dashboard.ts",
+		"./process-manager": "./src/process-manager.ts"
 	},
 	"bin": {
 		"bm2": "./src/index.ts"


### PR DESCRIPTION
**Problem**  
The documentation references imports from `"bm2/dashboard"` and `"bm2/process-manager"`, but these modules were not exposed in the `exports` field of `package.json`, causing import errors.

**Solution**  
This PR updates the `exports` field in `package.json` to properly expose the dashboard and process-manager modules.

**Changes**
- Added `./dashboard` and `./process-manager` to the `exports` map
- Consumers can now import these modules directly:

  ```js
  import ... from 'bm2/dashboard'
  import ... from 'bm2/process-manager'