### PR TITLE
Feat/raw log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ bm2 start server.ts --name api --wait-ready --listen-timeout 10000
 | `--health-check-timeout <ms>` | Probe timeout | `5000` |
 | `--health-check-max-fails <n>` | Failures before restart | `3` |
 | `--no-daemon`, `-d` | Run in foreground without a daemon (blocks) | `false` |
+| `--raw` | Also send child logs to stdout/stderr while retaining log files | `false` |
 
 > **Flags are position-independent.** `--no-daemon` (and all other flags) may appear anywhere relative to the script path:
 > ```
@@ -1061,6 +1062,18 @@ RUN bun add -g bm2
 CMD ["bm2", "start", "--no-daemon", "./server.ts"]
 ```
 
+### Docker logs and log files
+
+Use `--raw` with `--no-daemon` to keep BM2 log files while also exposing the
+managed process output to the container runtime:
+
+```dockerfile
+CMD ["bm2", "start", "--no-daemon", "--raw", "ecosystem.config.cjs"]
+```
+
+`--raw` mirrors child stdout to BM2 stdout and child stderr to BM2 stderr. It
+does not disable `outFile` or `errorFile`.
+
 **With additional options**
 
 ```dockerfile
@@ -1172,6 +1185,7 @@ The complete set of options available for each entry in the apps array:
 | `outFile` | `string` | `~/.bm2/logs/<name>-<id>-out.log` | Custom stdout log path |
 | `errorFile` | `string` | `~/.bm2/logs/<name>-<id>-error.log` | Custom stderr log path |
 | `mergeLogs` | `boolean` | `false` | Merge all instance logs into one file |
+| `raw` | `boolean` | `false` | Mirror child stdout and stderr to BM2 stdout and stderr |
 | `logDateFormat` | `string` | — | Date format for log line prefixes |
 | `logMaxSize` | `string` or `number` | `"10M"` | Max log file size before rotation |
 | `logRetain` | `number` | `5` | Number of rotated files to keep |

--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bm2",
       "dependencies": {
+        "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "pidusage": "^4.0.1",
         "ws": "^8.19.0",
@@ -31,6 +33,8 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -463,6 +463,10 @@ class BM2CLI {
     ) {
       
       const config = await this.loadEcosystemConfig(firstPositional);
+      const raw = args.includes("--raw");
+      if (raw) {
+        config.apps = config.apps.map((app) => ({ ...app, raw: true }));
+      }
       const res = await this.sendToDaemon({ type: "ecosystem", data: config });
       
       if (!res.success) {
@@ -470,7 +474,9 @@ class BM2CLI {
         process.exit(1);
       }
       
-      printProcessTable(res.data);
+      if (!raw && !config.apps.some((app) => app.raw)) {
+        printProcessTable(res.data);
+      }
             
       if (this.noDaemon) {
         await new Promise(() => {});
@@ -497,7 +503,9 @@ class BM2CLI {
         process.exit(1);
       }
   
-      printProcessTable(res.data);
+      if (!opts.raw) {
+        printProcessTable(res.data);
+      }
   
       if (this.noDaemon) {
         await new Promise(() => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import {
   VERSION,
   DAEMON_SOCKET,
   DAEMON_PID_FILE,
-  BM2_HOME,
   DASHBOARD_PORT,
   METRICS_PORT,
   DAEMON_OUT_LOG_FILE,
@@ -38,7 +37,6 @@ import type {
   StartOptions,
   EcosystemConfig,
   ProcessState,
-  LogEntry,
   LogItem,
 } from "./types";
 import { statusColor } from "./colors";
@@ -1141,7 +1139,7 @@ class BM2CLI {
     --port, -p <port>             Base port for cluster
     --env <KEY=VALUE>             Set environment variable
     --no-autorestart              Disable auto-restart
-    --no-daemon, -d              Run without daemon (blocks)
+    --no-daemon, -d               Run without daemon (blocks)
     --raw                         Mirror child logs to stdout and stderr
     --log, -o <file>              Custom stdout log path
     --error, -e <file>            Custom stderr log path

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,6 +366,9 @@ class BM2CLI {
         case "--merge-logs":
           opts.mergeLogs = true;
           break;
+        case "--raw":
+          opts.raw = true;
+          break;
         case "--log-date-format":
           opts.logDateFormat = args[++i];
           break;
@@ -1131,6 +1134,7 @@ class BM2CLI {
     --env <KEY=VALUE>             Set environment variable
     --no-autorestart              Disable auto-restart
     --no-daemon, -d              Run without daemon (blocks)
+    --raw                         Mirror child logs to stdout and stderr
     --log, -o <file>              Custom stdout log path
     --error, -e <file>            Custom stderr log path
     --namespace <ns>              Namespace grouping

--- a/src/process-container.ts
+++ b/src/process-container.ts
@@ -200,10 +200,10 @@ export class ProcessContainer {
     this.pid = proc.pid;
 
     if (proc.stdout && typeof proc.stdout !== "number") {
-      this.pipeStream(proc.stdout, logPaths.outFile);
+      this.pipeStream(proc.stdout, logPaths.outFile, "stdout");
     }
     if (proc.stderr && typeof proc.stderr !== "number") {
-      this.pipeStream(proc.stderr, logPaths.errFile);
+      this.pipeStream(proc.stderr, logPaths.errFile, "stderr");
     }
 
     proc.exited.then((code) => {
@@ -216,14 +216,18 @@ export class ProcessContainer {
   private pipeOutput(logPaths: { outFile: string; errFile: string }) {
     if (!this.process) return;
     if (this.process.stdout && typeof this.process.stdout !== "number") {
-      this.pipeStream(this.process.stdout, logPaths.outFile);
+      this.pipeStream(this.process.stdout, logPaths.outFile, "stdout");
     }
     if (this.process.stderr && typeof this.process.stderr !== "number") {
-      this.pipeStream(this.process.stderr, logPaths.errFile);
+      this.pipeStream(this.process.stderr, logPaths.errFile, "stderr");
     }
   }
 
-  private async pipeStream(stream: ReadableStream<Uint8Array>, filePath: string) {
+  private async pipeStream(
+    stream: ReadableStream<Uint8Array>,
+    filePath: string,
+    output: "stdout" | "stderr"
+  ) {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
 
@@ -244,6 +248,17 @@ export class ProcessContainer {
             remainder = "";
           }
           break;
+        }
+
+        // Keep the manager's log files while exposing the child output to the
+        // foreground process (and therefore to `docker logs`) when requested.
+        // Forward bytes instead of decoded strings so log content is unchanged.
+        if (this.config.raw) {
+          if (output === "stdout") {
+            process.stdout.write(value);
+          } else {
+            process.stderr.write(value);
+          }
         }
 
         // stream=true tells the decoder to hold multi-byte UTF-8 sequences

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -160,6 +160,7 @@ import type { ReadableStreamController } from "bun";
        interpreter: options.interpreter,
        interpreterArgs: options.interpreterArgs,
        mergeLogs: options.mergeLogs ?? false,
+       raw: options.raw ?? false,
        logDateFormat: options.logDateFormat,
        errorFile: options.errorFile,
        outFile: options.outFile,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface ProcessDescription {
   interpreter?: string;
   interpreterArgs?: string[];
   mergeLogs: boolean;
+  /** Also forward child stdout/stderr to BM2's own stdout/stderr. */
+  raw: boolean;
   logDateFormat?: string;
   errorFile?: string;
   outFile?: string;
@@ -132,6 +134,8 @@ export interface StartOptions {
   interpreter?: string;
   interpreterArgs?: string[];
   mergeLogs?: boolean;
+  /** Also forward child stdout/stderr to BM2's own stdout/stderr. */
+  raw?: boolean;
   logDateFormat?: string;
   errorFile?: string;
   outFile?: string;


### PR DESCRIPTION
## Summary

This PR adds a `--raw` option for Docker and foreground use cases, similar to `pm2-docker --raw`.

When enabled, BM2 keeps writing process output to the configured `outFile` and `errorFile` while also forwarding:

- child stdout to BM2 stdout
- child stderr to BM2 stderr

This makes application logs available through `docker logs` without losing file-based logging.

## Changes

- Add the `--raw` CLI option.
- Support `raw: true` in ecosystem configurations.
- Propagate `--raw` to every app in an ecosystem file.
- Suppress the startup process table in raw mode to avoid polluting application logs.
- Document raw logging usage for Docker.

## Usage

```dockerfile
CMD ["bm2", "start", "--no-daemon", "--raw", "ecosystem.config.cjs"]